### PR TITLE
DialogMusicInfo.xml:

### DIFF
--- a/16x9/DialogMusicInfo.xml
+++ b/16x9/DialogMusicInfo.xml
@@ -158,6 +158,29 @@
 								<textcolor>DialogColor1</textcolor>
 							</control>
 						</control>
+						
+						<!-- Duration -->
+						<control type="group">
+							<height>36</height>
+							<width>1170</width>
+							<visible>!String.IsEmpty(ListItem.Duration)</visible>
+							<control type="label">
+								<width>200</width>
+								<height>36</height>
+								<align>right</align>
+								<font>Font36</font>
+								<label>180</label>
+								<textcolor>DialogColor2</textcolor>
+							</control>
+							<control type="label">
+								<left>220</left>
+								<width>950</width>
+								<height>36</height>
+								<font>Font36</font>
+								<label>$VAR[Duration]</label>
+								<textcolor>DialogColor1</textcolor>
+							</control>
+						</control>						
 
 						<!-- Rating -->
 						<control type="group">
@@ -258,7 +281,7 @@
 								<textcolor>DialogColor1</textcolor>
 							</control>
 						</control>
-
+						
 						<!-- Type -->
 						<control type="group">
 							<height>36</height>

--- a/16x9/DialogPVRInfo.xml
+++ b/16x9/DialogPVRInfo.xml
@@ -81,11 +81,11 @@
 							<width>950</width>
 							<height>36</height>
 							<font>Font36</font>
-							<label>$INFO[ListItem.Duration]</label>
+							<label>$VAR[Duration]</label>
 							<textcolor>DialogColor1</textcolor>
 						</control>
 					</control>
-
+					
 					<!-- Channel Name -->
 					<control type="group">
 						<height>36</height>

--- a/16x9/DialogVideoInfo.xml
+++ b/16x9/DialogVideoInfo.xml
@@ -195,7 +195,7 @@
 							<width>950</width>
 							<height>36</height>
 							<font>Font36</font>
-							<label>$INFO[ListItem.Duration,, mins]</label>
+							<label>$VAR[Duration]</label>
 							<textcolor>DialogColor1</textcolor>
 						</control>
 					</control>
@@ -264,7 +264,7 @@
 							<width>950</width>
 							<height>36</height>
 							<font>Font36</font>
-							<label>$INFO[ListItem.VideoResolution]</label>
+							<label>$VAR[VideoResolution,,p]</label>
 							<textcolor>DialogColor1</textcolor>
 						</control>
 					</control>

--- a/16x9/Includes.xml
+++ b/16x9/Includes.xml
@@ -133,8 +133,8 @@
 			<!-- Window heading -->
 			<control type="label">
 				<left>120</left>
-				<top>110</top>
-				<width>1680</width>
+				<top>127</top>
+				<width>1400</width>
 				<height>33</height>
 				<aligny>top</aligny>
 				<label>$PARAM[heading]</label>
@@ -162,12 +162,12 @@
 				<!-- Time -->
 				<control type="label">
 					<right>120</right>
-					<top>110</top>
-					<width>1680</width>
+					<top>127</top>
+					<width>1400</width>
 					<height>33</height>
 					<aligny>top</aligny>
 					<align>right</align>
-					<label>$INFO[System.Time]</label>
+					<label>$INFO[System.Time(hh:mm:ss)]</label>
 					<font>Font33</font>
 					<textcolor>DialogColor1</textcolor>
 					<visible>!Player.HasMedia | !Integer.IsGreater(Player.Duration,0)</visible>
@@ -180,15 +180,15 @@
 					<control type="fadelabel">
 						<right>170</right>
 						<top>93</top>
-						<width>1680</width>
+						<width>1400</width>
 						<height>33</height>
 						<aligny>top</aligny>
 						<align>right</align>
 						<label>$INFO[VideoPlayer.TVShowTitle]</label>
 						<label>$INFO[VideoPlayer.ChannelNumber,[LIGHT](,)[/LIGHT] ]$INFO[VideoPlayer.ChannelName]</label>
-						<label>$INFO[VideoPlayer.Season,[LIGHT]s,[/LIGHT]]$INFO[VideoPlayer.Episode,[LIGHT]e,[/LIGHT]  ]$INFO[VideoPlayer.Title]</label>
+						<label>$VAR[Seasonplaying,[LIGHT],[/LIGHT]]$VAR[Episodeplaying,[LIGHT],[/LIGHT]  ]$INFO[VideoPlayer.Title]</label>
 						<label>$INFO[VideoPlayer.EpisodeName]</label>
-						<label>$INFO[Player.FinishTime,[LIGHT]Finishes at ,[/LIGHT]  ]$INFO[System.Time]</label>
+						<label>$INFO[System.Time,[LIGHT]$LOCALIZE[142] [/LIGHT], / ]$INFO[Player.FinishTime,[LIGHT]$LOCALIZE[19081] [/LIGHT]]</label>
 						<visible>Player.HasVideo</visible>
 						<pauseatend>5000</pauseatend>
 					</control>
@@ -197,13 +197,13 @@
 					<control type="fadelabel">
 						<right>170</right>
 						<top>93</top>
-						<width>1680</width>
+						<width>1400</width>
 						<height>33</height>
 						<aligny>top</aligny>
 						<align>right</align>
 						<label>[LIGHT]$INFO[MusicPlayer.TrackNumber,,. ][/LIGHT]$INFO[MusicPlayer.Title]</label>
-						<label>[LIGHT]$INFO[MusicPlayer.Artist,,  ][/LIGHT]$INFO[MusicPlayer.Album]</label>
-						<label>$INFO[Player.FinishTime,[LIGHT]Finishes at ,[/LIGHT]  ]$INFO[System.Time]</label>
+						<label>[LIGHT]$INFO[MusicPlayer.Artist,,:  ][/LIGHT]$INFO[MusicPlayer.Album]</label>
+						<label>$INFO[System.Time,[LIGHT]$LOCALIZE[142] [/LIGHT], / ]$INFO[Player.FinishTime,[LIGHT]$LOCALIZE[19081] [/LIGHT]]</label>
 						<visible>Player.HasAudio + String.IsEmpty(VideoPlayer.ChannelName)</visible>
 						<pauseatend>5000</pauseatend>
 					</control>
@@ -212,13 +212,13 @@
 					<control type="fadelabel">
 						<right>170</right>
 						<top>93</top>
-						<width>1680</width>
+						<width>1400</width>
 						<height>33</height>
 						<aligny>top</aligny>
 						<align>right</align>
 						<label>$INFO[Player.Title]</label>
 						<label>$INFO[VideoPlayer.ChannelNumber,[LIGHT](,)[/LIGHT] ]$INFO[VideoPlayer.ChannelName]</label>
-						<label>$INFO[Player.FinishTime,[LIGHT]Finishes at ,[/LIGHT]  ]$INFO[System.Time]</label>
+						<label>$INFO[System.Time,[LIGHT]$LOCALIZE[142] [/LIGHT], / ]$INFO[Player.FinishTime,[LIGHT]$LOCALIZE[19081] [/LIGHT]]</label>
 						<visible>Player.HasAudio + !String.IsEmpty(VideoPlayer.ChannelName)</visible>
 						<pauseatend>5000</pauseatend>
 					</control>
@@ -227,7 +227,7 @@
 					<control type="label">
 						<right>170</right>
 						<top>127</top>
-						<width>1680</width>
+						<width>1400</width>
 						<height>33</height>
 						<aligny>top</aligny>
 						<align>right</align>
@@ -374,7 +374,7 @@
 	<include name="MediaFlags">
 		<control type="grouplist">
 			<left>120</left>
-			<bottom>110</bottom>
+			<bottom>154</bottom>
 			<width>800</width>
 			<height>44</height>
 			<itemgap>0</itemgap>
@@ -395,11 +395,23 @@
 				<width>auto</width>
 				<height>44</height>
 				<align>right</align>
-				<label>$INFO[ListItem.VideoCodec,,]$INFO[ListItem.VideoResolution, ,p]</label>
-				<font>Font33</font>
+				<label>$VAR[VideoCodec,,]$VAR[3DMode, ,]$VAR[VideoResolution, ,p]$INFO[ListItem.VideoAspect, (,:1)]</label>
+				<font>Font30</font>
 				<textcolor>TextColor2</textcolor>
 				<visible>!String.IsEmpty(ListItem.VideoCodec) + !String.IsEmpty(ListItem.VideoResolution)</visible>
 			</control>
+		</control>
+
+		<control type="grouplist">
+			<left>120</left>
+			<bottom>120</bottom>
+			<width>800</width>
+			<height>44</height>
+			<itemgap>0</itemgap>
+			<align>left</align>
+			<orientation>horizontal</orientation>
+			<usecontrolcoords>true</usecontrolcoords>
+			<visible>Integer.IsGreater(Container.NumItems,0)</visible>
 
 			<!-- Audio flags -->
 			<control type="image">
@@ -413,14 +425,14 @@
 				<width>auto</width>
 				<height>44</height>
 				<align>right</align>
-				<label>$INFO[ListItem.AudioCodec,,]$VAR[AudioChannels, ,]</label>
-				<font>Font33</font>
+				<label>$VAR[Atmos,,]$VAR[DTSX,,]$VAR[AudioCodec,,]$VAR[AudioChannels, ,]</label>
+				<font>Font30</font>
 				<textcolor>TextColor2</textcolor>
 				<visible>!String.IsEmpty(ListItem.AudioCodec)</visible>
 			</control>
 		</control>
 		<control type="grouplist">
-			<left>120</left>
+			<left>115</left>
 			<bottom>66</bottom>
 			<width>800</width>
 			<height>44</height>
@@ -443,7 +455,7 @@
 				<width>auto</width>
 				<height>44</height>
 				<align>right</align>
-				<label>$INFO[ListItem.Duration]</label>
+				<label>$INFO[ListItem.Duration, ,]</label>
 				<font>Font33</font>
 				<textcolor>TextColor2</textcolor>
 				<visible>!String.IsEmpty(ListItem.Duration) + !Container.Content(tvshows) + !Container.Content(seasons)</visible>
@@ -452,7 +464,7 @@
 				<width>auto</width>
 				<height>44</height>
 				<align>right</align>
-				<label> $LOCALIZE[12391]</label>
+				<label>$LOCALIZE[12391]</label>
 				<font>Font33</font>
 				<textcolor>TextColor2</textcolor>
 				<visible>!String.IsEmpty(ListItem.Duration) + !String.Contains(ListItem.Duration,:) + !Container.Content(tvshows) + !Container.Content(seasons)</visible>

--- a/16x9/MusicVisualisation.xml
+++ b/16x9/MusicVisualisation.xml
@@ -32,22 +32,76 @@
 			</control>
 
 			<!-- Now playing -->
+			<control type="fadelabel">
+				<left>980</left>
+				<top>340</top>
+				<width>700</width>
+				<height>40</height>
+				<pauseatend>5000</pauseatend>
+				<label>$INFO[MusicPlayer.Artist,,]</label>
+			</control>
+			<control type="fadelabel">
+				<left>980</left>
+				<top>380</top>
+				<width>700</width>
+				<height>40</height>
+				<pauseatend>5000</pauseatend>
+				<label>$INFO[MusicPlayer.Album,,]</label>
+			</control>
+			<control type="fadelabel">
+				<left>980</left>
+				<top>420</top>
+				<width>700</width>
+				<height>40</height>
+				<pauseatend>5000</pauseatend>
+				<label>$INFO[MusicPlayer.TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[Player.Title,,]</label>
+			</control>
 			<control type="label">
 				<left>980</left>
-				<top>300</top>
-				<width>960</width>
-				<height>300</height>
-				<label>$INFO[MusicPlayer.Artist,,[CR]]$INFO[MusicPlayer.Album,,[CR]]$INFO[MusicPlayer.TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[Player.Title,,[CR]]$INFO[VideoPlayer.ChannelName,[LIGHT],[/LIGHT]]</label>
+				<top>460</top>
+				<width>700</width>
+				<height>40</height>
+				<label>$INFO[VideoPlayer.ChannelName,[LIGHT],[/LIGHT][CR]]$VAR[MusicPlayerCodec,[LIGHT],[/LIGHT]  ]$INFO[MusicPlayer.BitRate,[LIGHT](,kBit/s)[/LIGHT]  ]$VAR[MusicPlayerChannels,[LIGHT],[/LIGHT]  ]$INFO[MusicPlayer.SampleRate,[LIGHT],kHz[/LIGHT]]</label>
 			</control>
 
 			<!-- Next playing -->
 			<control type="label">
 				<left>980</left>
-				<bottom>250</bottom>
-				<width>960</width>
-				<height>300</height>
+				<top>600</top>
+				<width>700</width>
+				<height>40</height>
 				<font>font27</font>
-				<label>$VAR[MusicNextPlaying,[LIGHT]$LOCALIZE[209]:[/LIGHT][CR],]</label>
+				<label>[LIGHT]$LOCALIZE[209]:[/LIGHT]</label>
+				<visible>!String.IsEmpty(MusicPlayer.Offset(1).Title)</visible>
+			</control>
+			<control type="fadelabel">
+				<left>980</left>
+				<top>645</top>
+				<width>700</width>
+				<height>30</height>
+				<font>font27</font>
+				<pauseatend>5000</pauseatend>
+				<label>$VAR[MusicNextPlaying1,,]</label>
+				<visible>!String.IsEmpty(MusicPlayer.Offset(1).Title)</visible>
+			</control>
+			<control type="fadelabel">
+				<left>980</left>
+				<top>675</top>
+				<width>700</width>
+				<height>30</height>
+				<font>font27</font>
+				<pauseatend>5000</pauseatend>
+				<label>$VAR[MusicNextPlaying2,,]</label>
+				<visible>!String.IsEmpty(MusicPlayer.Offset(1).Title)</visible>
+			</control>
+			<control type="fadelabel">
+				<left>980</left>
+				<top>705</top>
+				<width>700</width>
+				<height>30</height>
+				<font>font27</font>
+				<pauseatend>5000</pauseatend>
+				<label>$VAR[MusicNextPlaying3,,]</label>
 				<visible>!String.IsEmpty(MusicPlayer.Offset(1).Title)</visible>
 			</control>
 		</control>

--- a/16x9/Variables.xml
+++ b/16x9/Variables.xml
@@ -400,12 +400,148 @@
 		<value condition="String.IsEmpty(ListItem.Season) + String.IsEmpty(ListItem.Episode) + !String.IsEmpty(ListItem.Premiered)">Aired on $INFO[ListItem.Premiered]</value>
 	</variable>
 
+		<!-- Audio Channel labels -->
 	<variable name="AudioChannels">
-		<value condition="Integer.IsEqual(ListItem.AudioChannels,1)">Mono</value>
-		<value condition="Integer.IsEqual(ListItem.AudioChannels,2)">Stereo</value>
-		<value condition="Integer.IsGreater(ListItem.AudioChannels,2)">Surround</value>
+		<value condition="Integer.IsEqual(ListItem.AudioChannels,1)">1.0</value>
+		<value condition="Integer.IsEqual(ListItem.AudioChannels,2)">2.0</value>
+		<value condition="Integer.IsEqual(ListItem.AudioChannels,4)">3.1</value>
+		<value condition="Integer.IsEqual(ListItem.AudioChannels,5)">4.1</value>
+		<value condition="Integer.IsEqual(ListItem.AudioChannels,6)">5.1</value>
+		<value condition="Integer.IsEqual(ListItem.AudioChannels,7)">6.1</value>
+		<value condition="Integer.IsEqual(ListItem.AudioChannels,8)">7.1</value>
+		<value condition="Integer.IsEqual(ListItem.AudioChannels,10)">9.1</value>
 	</variable>
 
+	<variable name="MusicPlayerChannels">
+		<value condition="Integer.IsEqual(MusicPlayer.Channels,1)">1.0</value>
+		<value condition="Integer.IsEqual(MusicPlayer.Channels,2)">2.0</value>
+		<value condition="Integer.IsEqual(MusicPlayer.Channels,4)">3.1</value>
+		<value condition="Integer.IsEqual(MusicPlayer.Channels,5)">4.1</value>
+		<value condition="Integer.IsEqual(MusicPlayer.Channels,6)">5.1</value>
+		<value condition="Integer.IsEqual(MusicPlayer.Channels,7)">6.1</value>
+		<value condition="Integer.IsEqual(MusicPlayer.Channels,8)">7.1</value>
+		<value condition="Integer.IsEqual(MusicPlayer.Channels,10)">9.1</value>
+	</variable>
+
+		<!-- Audio Codec labels -->
+	<variable name="Atmos">
+		<value condition="String.Contains(ListItem.Filenameandpath,-atmos-) | String.Contains(ListItem.Filenameandpath,.atmos.) | String.Contains(ListItem.Filenameandpath, atmos ) | String.Contains(ListItem.Filenameandpath,_atmos_) | String.Contains(ListItem.Filenameandpath,-Atmos-) | String.Contains(ListItem.Filenameandpath,.Atmos.) | String.Contains(ListItem.Filenameandpath, Atmos ) | String.Contains(ListItem.Filenameandpath,_Atmos_) | String.Contains(ListItem.Filenameandpath,-ATMOS-) | String.Contains(ListItem.Filenameandpath,.ATMOS.) | String.Contains(ListItem.Filenameandpath, ATMOS ) | String.Contains(ListItem.Filenameandpath,_ATMOS_)">Atmos </value>
+	</variable>
+
+	<variable name="DTSX">
+		<value condition="String.Contains(ListItem.Filenameandpath,-DTS-X-) | String.Contains(ListItem.Filenameandpath,-DTSX-) | String.Contains(ListItem.Filenameandpath,-DTS - X-) | String.Contains(ListItem.Filenameandpath,-DTS_-_X-) | String.Contains(ListItem.Filenameandpath,-DTS X-) | String.Contains(ListItem.Filenameandpath,-DTS_X-) | String.Contains(ListItem.Filenameandpath,.DTS-X.) | String.Contains(ListItem.Filenameandpath,.DTSX.) | String.Contains(ListItem.Filenameandpath,.DTS - X.) | String.Contains(ListItem.Filenameandpath,.DTS_-_X.) | String.Contains(ListItem.Filenameandpath,.DTS X.) | String.Contains(ListItem.Filenameandpath,.DTS_X.) | String.Contains(ListItem.Filenameandpath, DTS-X ) | String.Contains(ListItem.Filenameandpath, DTSX ) | String.Contains(ListItem.Filenameandpath, DTS - X ) | String.Contains(ListItem.Filenameandpath, DTS_-_X ) | String.Contains(ListItem.Filenameandpath, DTS X ) | String.Contains(ListItem.Filenameandpath, DTS_X ) | String.Contains(ListItem.Filenameandpath,_DTS-X_) | String.Contains(ListItem.Filenameandpath,_DTSX_) | String.Contains(ListItem.Filenameandpath,_DTS - X_) | String.Contains(ListItem.Filenameandpath,_DTS_-_X_) | String.Contains(ListItem.Filenameandpath,_DTS X_) | String.Contains(ListItem.Filenameandpath,_DTS_X_)">DTS:X </value>
+	</variable>
+
+	<variable name="AudioCodec">
+		<value condition="String.IsEqual(ListItem.AudioCodec,aac) | String.IsEqual(ListItem.AudioCodec,aac_latm)">AAC</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,ac3)">Dolby Digital</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,aif) | String.IsEqual(ListItem.AudioCodec,aiff)">AIFF</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,aifc)">AIFC</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,alac)">Apple</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,ape)">APE</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,avc)">AVC</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,cdda)">Audio-CD</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dca) | String.IsEqual(ListItem.AudioCodec,dts)">DTS</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dolbydigital)">Dolby Digital</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_hra)">DTS-HD HRA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma) | String.IsEqual(ListItem.AudioCodec,dtsma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,eac3)">Dolby Digital+</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,flac)">FLAC</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,mp1)">MP1</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,mp2)">MP2</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,mp3)">MP3</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,ogg)">OGG</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,opus)">Opus</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,pcm) | String.IsEqual(ListItem.AudioCodec,pcm_bluray) | String.IsEqual(ListItem.AudioCodec,pcm_s16le) | String.IsEqual(ListItem.AudioCodec,pcm_s24le)">PCM</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,truehd)">Dolby TrueHD</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,vorbis)">Vorbis</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,wav)">WAV</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,wavpack)">WAVP</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,wma) | String.IsEqual(ListItem.AudioCodec,wmapro) | String.IsEqual(ListItem.AudioCodec,wmav2)">WMA</value>
+	</variable>
+
+	<variable name="MusicPlayerCodec">
+		<value condition="String.IsEqual(MusicPlayer.Codec,aac) | String.IsEqual(MusicPlayer.Codec,aac_latm)">AAC</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,ac3)">Dolby Digital</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,aif) | String.IsEqual(MusicPlayer.Codec,aiff)">AIFF</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,aifc)">AIFC</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,alac)">Apple</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,ape)">APE</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,avc)">AVC</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,cdda)">Audio-CD</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,dca) | String.IsEqual(MusicPlayer.Codec,dts)">DTS</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,dolbydigital)">Dolby Digital</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_hra)">DTS-HD HRA</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,dtshd_ma) | String.IsEqual(MusicPlayer.Codec,dtsma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,eac3)">Dolby Digital+</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,flac)">FLAC</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,mp1)">MP1</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,mp2)">MP2</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,mp3)">MP3</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,ogg)">OGG</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,opus)">Opus</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,pcm) | String.IsEqual(MusicPlayer.Codec,pcm_bluray) | String.IsEqual(MusicPlayer.Codec,pcm_s16le) | String.IsEqual(MusicPlayer.Codec,pcm_s24le)">PCM</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,truehd)">Dolby TrueHD</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,vorbis)">Vorbis</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,wav)">WAV</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,wavpack)">WAVP</value>
+		<value condition="String.IsEqual(MusicPlayer.Codec,wma) | String.IsEqual(MusicPlayer.Codec,wmapro) | String.IsEqual(MusicPlayer.Codec,wmav2)">WMA</value>
+	</variable>
+
+		<!-- Audio/Video Duration -->
+	<variable name="Duration">
+		<value condition="!String.Contains(ListItem.Duration,:)">$INFO[ListItem.Duration,, ]$LOCALIZE[12391]</value>
+		<value>$INFO[ListItem.Duration]</value>
+	</variable>
+		
+		<!-- Video Resolution labels -->
+	<variable name="VideoResolution">
+		<value condition="String.IsEqual(ListItem.VideoResolution,4K)">2160</value>
+		<value>$INFO[ListItem.VideoResolution,,]</value>
+	</variable>
+	
+		<!-- Video Codec labels -->
+	<variable name="VideoCodec">
+		<value condition="String.IsEqual(ListItem.VideoCodec,3iv2)">3IV2</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,avc1)">AVC-1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,bluray) | String.IsEqual(ListItem.VideoCodec,hdmv)">Blu-ray</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,div2) | String.IsEqual(ListItem.VideoCodec,div3) | String.IsEqual(ListItem.VideoCodec,divx) | String.IsEqual(ListItem.VideoCodec,divx 4) | String.IsEqual(ListItem.VideoCodec,dx50)">DivX</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,dvd)">DVD</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,flv)">FLV</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,h264)">H.264</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,hddvd)">HD-DVD</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,hev1) | String.IsEqual(ListItem.VideoCodec,hevc) | String.IsEqual(ListItem.VideoCodec,hvc1)">H.265</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,microsoft) | String.IsEqual(ListItem.VideoCodec,mp42) | String.IsEqual(ListItem.VideoCodec,mp43) | String.IsEqual(ListItem.VideoCodec,mp4v) | String.IsEqual(ListItem.VideoCodec,mpg4) | String.IsEqual(ListItem.VideoCodec,mpeg4)">MPEG-4</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg1) | String.IsEqual(ListItem.VideoCodec,mpeg1video)">MPEG-1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,mpeg2) | String.IsEqual(ListItem.VideoCodec,mpeg2video)">MPEG-2</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,rv40)">RV40</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,svq1)">SVQ1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,svq3)">SVQ3</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,theora)">Theora</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,tv)">TV</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,wvc1)">VC-1</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,vhs)">VHS</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,vp8) | String.IsEqual(ListItem.VideoCodec,vp9)">Webm</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,wmv) | String.IsEqual(ListItem.VideoCodec,wmv2) | String.IsEqual(ListItem.VideoCodec,wmv3)">WMV</value>
+		<value condition="String.IsEqual(ListItem.VideoCodec,xvid)">XviD</value>
+	</variable>
+
+		<!-- 3D Video label -->
+	<variable name="3DMode">
+		<value condition="ListItem.IsStereoscopic | String.Contains(ListItem.Filenameandpath,-3d-) | String.Contains(ListItem.Filenameandpath,.3d.) | String.Contains(ListItem.Filenameandpath, 3d ) | String.Contains(ListItem.Filenameandpath,_3d_) | String.Contains(ListItem.Filenameandpath,-3D-) | String.Contains(ListItem.Filenameandpath,.3D.) | String.Contains(ListItem.Filenameandpath, 3D ) | String.Contains(ListItem.Filenameandpath,_3D_) | String.Contains(ListItem.Filenameandpath,-3-d-) | String.Contains(ListItem.Filenameandpath,.3-d.) | String.Contains(ListItem.Filenameandpath, 3-d ) | String.Contains(ListItem.Filenameandpath,_3-d_) | String.Contains(ListItem.Filenameandpath,-3-D-) | String.Contains(ListItem.Filenameandpath,.3-D.) | String.Contains(ListItem.Filenameandpath, 3-D ) | String.Contains(ListItem.Filenameandpath,_3-D_) | String.Contains(ListItem.Filenameandpath,-3.-.d-) | String.Contains(ListItem.Filenameandpath,.3.-.d.) | String.Contains(ListItem.Filenameandpath, 3.-.d ) | String.Contains(ListItem.Filenameandpath,_3.-.d_) | String.Contains(ListItem.Filenameandpath,-3.-.D-) | String.Contains(ListItem.Filenameandpath,.3.-.D.) | String.Contains(ListItem.Filenameandpath, 3.-.D ) | String.Contains(ListItem.Filenameandpath,_3.-.D_) | String.Contains(ListItem.Filenameandpath,-3 - d-) | String.Contains(ListItem.Filenameandpath,.3 - d.) | String.Contains(ListItem.Filenameandpath, 3 - d ) | String.Contains(ListItem.Filenameandpath,_3 - d_) | String.Contains(ListItem.Filenameandpath,-3 - D-) | String.Contains(ListItem.Filenameandpath,.3 - D.) | String.Contains(ListItem.Filenameandpath, 3 - D ) | String.Contains(ListItem.Filenameandpath,_3 - D_) | String.Contains(ListItem.Filenameandpath,-3_-_d-) | String.Contains(ListItem.Filenameandpath,.3_-_d.) | String.Contains(ListItem.Filenameandpath, 3_-_d ) | String.Contains(ListItem.Filenameandpath,_3_-_d_) | String.Contains(ListItem.Filenameandpath,-3_-_D-) | String.Contains(ListItem.Filenameandpath,.3_-_D.) | String.Contains(ListItem.Filenameandpath, 3_-_D ) | String.Contains(ListItem.Filenameandpath,_3_-_D_) | String.Contains(ListItem.Filenameandpath,-hsbs-) | String.Contains(ListItem.Filenameandpath,.hsbs.) | String.Contains(ListItem.Filenameandpath, hsbs ) | String.Contains(ListItem.Filenameandpath,_hsbs_) | String.Contains(ListItem.Filenameandpath,-HSBS-) | String.Contains(ListItem.Filenameandpath,.HSBS.) | String.Contains(ListItem.Filenameandpath, HSBS ) | String.Contains(ListItem.Filenameandpath,_HSBS_) | String.Contains(ListItem.Filenameandpath,-h-sbs-) | String.Contains(ListItem.Filenameandpath,.h-sbs.) | String.Contains(ListItem.Filenameandpath, h-sbs ) | String.Contains(ListItem.Filenameandpath,_h-sbs_) | String.Contains(ListItem.Filenameandpath,-H-SBS-) | String.Contains(ListItem.Filenameandpath,.H-SBS.) | String.Contains(ListItem.Filenameandpath, H-SBS ) | String.Contains(ListItem.Filenameandpath,_H-SBS_) | String.Contains(ListItem.Filenameandpath,-h.-.sbs-) | String.Contains(ListItem.Filenameandpath,.h.-.sbs.) | String.Contains(ListItem.Filenameandpath, h.-.sbs ) | String.Contains(ListItem.Filenameandpath,_h.-.sbs_) | String.Contains(ListItem.Filenameandpath,-H.-.SBS-) | String.Contains(ListItem.Filenameandpath,.H.-.SBS.) | String.Contains(ListItem.Filenameandpath, H.-.SBS ) | String.Contains(ListItem.Filenameandpath,_H.-.SBS_) | String.Contains(ListItem.Filenameandpath,-h - sbs-) | String.Contains(ListItem.Filenameandpath,.h - sbs.) | String.Contains(ListItem.Filenameandpath, h - sbs ) | String.Contains(ListItem.Filenameandpath,_h - sbs_) | String.Contains(ListItem.Filenameandpath,-H - SBS-) | String.Contains(ListItem.Filenameandpath,.H - SBS.) | String.Contains(ListItem.Filenameandpath, H - SBS ) | String.Contains(ListItem.Filenameandpath,_H - SBS_) | String.Contains(ListItem.Filenameandpath,-h_-_sbs-) | String.Contains(ListItem.Filenameandpath,.h_-_sbs.) | String.Contains(ListItem.Filenameandpath, h_-_sbs ) | String.Contains(ListItem.Filenameandpath,_h_-_sbs_) | String.Contains(ListItem.Filenameandpath,-H_-_SBS-) | String.Contains(ListItem.Filenameandpath,.H_-_SBS.) | String.Contains(ListItem.Filenameandpath, H_-_SBS ) | String.Contains(ListItem.Filenameandpath,_H_-_SBS_) | String.Contains(ListItem.Filenameandpath,-htab-) | String.Contains(ListItem.Filenameandpath,.htab.) | String.Contains(ListItem.Filenameandpath, htab ) | String.Contains(ListItem.Filenameandpath,_htab_) | String.Contains(ListItem.Filenameandpath,-HTAB-) | String.Contains(ListItem.Filenameandpath,.HTAB.) | String.Contains(ListItem.Filenameandpath, HTAB ) | String.Contains(ListItem.Filenameandpath,_HTAB_) | String.Contains(ListItem.Filenameandpath,-h-tab-) | String.Contains(ListItem.Filenameandpath,.h-tab.) | String.Contains(ListItem.Filenameandpath, h-tab ) | String.Contains(ListItem.Filenameandpath,_h-tab_) | String.Contains(ListItem.Filenameandpath,-H-TAB-) | String.Contains(ListItem.Filenameandpath,.H-TAB.) | String.Contains(ListItem.Filenameandpath, H-TAB ) | String.Contains(ListItem.Filenameandpath,_H-TAB_) | String.Contains(ListItem.Filenameandpath,-h - tab-) | String.Contains(ListItem.Filenameandpath,.h - tab.) | String.Contains(ListItem.Filenameandpath, h - tab ) | String.Contains(ListItem.Filenameandpath,_h - tab_) | String.Contains(ListItem.Filenameandpath,-H - TAB-) | String.Contains(ListItem.Filenameandpath,.H - TAB.) | String.Contains(ListItem.Filenameandpath, H - TAB ) | String.Contains(ListItem.Filenameandpath,_H - TAB_) | String.Contains(ListItem.Filenameandpath,-h.-.tab-) | String.Contains(ListItem.Filenameandpath,.h.-.tab.) | String.Contains(ListItem.Filenameandpath, h.-.tab ) | String.Contains(ListItem.Filenameandpath,_h.-.tab_) | String.Contains(ListItem.Filenameandpath,-H.-.TAB-) | String.Contains(ListItem.Filenameandpath,.H.-.TAB.) | String.Contains(ListItem.Filenameandpath, H.-.TAB ) | String.Contains(ListItem.Filenameandpath,_H.-.TAB_) | String.Contains(ListItem.Filenameandpath,-h_-_tab-) | String.Contains(ListItem.Filenameandpath,.h_-_tab.) | String.Contains(ListItem.Filenameandpath, h_-_tab ) | String.Contains(ListItem.Filenameandpath,_h_-_tab_) | String.Contains(ListItem.Filenameandpath,-H_-_TAB-) | String.Contains(ListItem.Filenameandpath,.H_-_TAB.) | String.Contains(ListItem.Filenameandpath, H_-_TAB ) | String.Contains(ListItem.Filenameandpath,_H_-_TAB_) | String.Contains(ListItem.Filenameandpath,-hou-) | String.Contains(ListItem.Filenameandpath,.hou.) | String.Contains(ListItem.Filenameandpath, hou ) | String.Contains(ListItem.Filenameandpath,_hou_) | String.Contains(ListItem.Filenameandpath,-HOU-) | String.Contains(ListItem.Filenameandpath,.HOU.) | String.Contains(ListItem.Filenameandpath, HOU ) | String.Contains(ListItem.Filenameandpath,_HOU_) | String.Contains(ListItem.Filenameandpath,-h-ou-) | String.Contains(ListItem.Filenameandpath,.h-ou.) | String.Contains(ListItem.Filenameandpath, h-ou ) | String.Contains(ListItem.Filenameandpath,_h-ou_) | String.Contains(ListItem.Filenameandpath,-H-OU-) | String.Contains(ListItem.Filenameandpath,.H-OU.) | String.Contains(ListItem.Filenameandpath, H-OU ) | String.Contains(ListItem.Filenameandpath,_H-OU_) | String.Contains(ListItem.Filenameandpath,-h.-.ou-) | String.Contains(ListItem.Filenameandpath,.h.-.ou.) | String.Contains(ListItem.Filenameandpath, h.-.ou ) | String.Contains(ListItem.Filenameandpath,_h.-.ou_) | String.Contains(ListItem.Filenameandpath,-H.-.OU-) | String.Contains(ListItem.Filenameandpath,.H.-.OU.) | String.Contains(ListItem.Filenameandpath, H.-.OU ) | String.Contains(ListItem.Filenameandpath,_H.-.OU_) | String.Contains(ListItem.Filenameandpath,-h - ou-) | String.Contains(ListItem.Filenameandpath,.h - ou.) | String.Contains(ListItem.Filenameandpath, h - ou ) | String.Contains(ListItem.Filenameandpath,_h - ou_) | String.Contains(ListItem.Filenameandpath,-H - OU-) | String.Contains(ListItem.Filenameandpath,.H - OU.) | String.Contains(ListItem.Filenameandpath, H - OU ) | String.Contains(ListItem.Filenameandpath,_H - OU_) | String.Contains(ListItem.Filenameandpath,-h_-_ou-) | String.Contains(ListItem.Filenameandpath,.h_-_ou.) | String.Contains(ListItem.Filenameandpath, h_-_ou ) | String.Contains(ListItem.Filenameandpath,_h_-_ou_) | String.Contains(ListItem.Filenameandpath,-H_-_OU-) | String.Contains(ListItem.Filenameandpath,.H_-_OU.) | String.Contains(ListItem.Filenameandpath, H_-_OU ) | String.Contains(ListItem.Filenameandpath,_H_-_OU_) | String.Contains(ListItem.Filenameandpath,-sbs-) | String.Contains(ListItem.Filenameandpath,.sbs.) | String.Contains(ListItem.Filenameandpath, sbs ) | String.Contains(ListItem.Filenameandpath,_sbs_) | String.Contains(ListItem.Filenameandpath,-SBS-) | String.Contains(ListItem.Filenameandpath,.SBS.) | String.Contains(ListItem.Filenameandpath, SBS ) | String.Contains(ListItem.Filenameandpath,_SBS_) | String.Contains(ListItem.Filenameandpath,-tab-) | String.Contains(ListItem.Filenameandpath,.tab.) | String.Contains(ListItem.Filenameandpath, tab ) | String.Contains(ListItem.Filenameandpath,_tab_) | String.Contains(ListItem.Filenameandpath,-TAB-) | String.Contains(ListItem.Filenameandpath,.TAB.) | String.Contains(ListItem.Filenameandpath, TAB ) | String.Contains(ListItem.Filenameandpath,_TAB_) | String.Contains(ListItem.Filenameandpath,-ou-) | String.Contains(ListItem.Filenameandpath,.ou.) | String.Contains(ListItem.Filenameandpath, ou ) | String.Contains(ListItem.Filenameandpath,_ou_) | String.Contains(ListItem.Filenameandpath,-OU-) | String.Contains(ListItem.Filenameandpath,.OU.) | String.Contains(ListItem.Filenameandpath, OU ) | String.Contains(ListItem.Filenameandpath,_OU_)">3D</value>
+	</variable>
+	
+		<!-- Season/Episode playing label -->
+	<variable name="Seasonplaying">
+		<value condition="Integer.IsLessOrEqual(VideoPlayer.Season,9)">$INFO[VideoPlayer.Season,S0,]</value>
+		<value condition="Integer.IsGreaterOrEqual(VideoPlayer.Season,10)">$INFO[VideoPlayer.Season,S,]</value>
+	</variable>
+	
+	<variable name="Episodeplaying">
+		<value condition="Integer.IsLessOrEqual(VideoPlayer.Episode,9)">$INFO[VideoPlayer.Episode,E0,]</value>
+		<value condition="Integer.IsGreaterOrEqual(VideoPlayer.Episode,10)">$INFO[VideoPlayer.Episode,E,]</value>
+	</variable>
+		
 	<variable name="ContentType">
 		<value condition="Container.Content(movies) + !Integer.IsGreater(Container.NumItems,1)">$LOCALIZE[20338]</value>
 		<value condition="Container.Content(movies) + Integer.IsGreater(Container.NumItems,1)">$LOCALIZE[342]</value>
@@ -493,7 +629,7 @@
 	</variable>
 
 	<variable name="skinshortcuts-disableindicator">
-		<value condition="String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)">[COLOR darkred]×[/COLOR] </value>
+		<value condition="String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)">[COLOR darkred]؛/COLOR] </value>
 		<value />
 	</variable>
 
@@ -583,11 +719,26 @@
 		<value condition="!String.IsEmpty(ListItem.Season)">$INFO[ListItem.Season,$LOCALIZE[20373] , / ]$INFO[ListItem.Episode,$LOCALIZE[20359] ]</value>
 	</variable>
 
-	<variable name="MusicNextPlaying">
+	<!-- Music Next Playing -->
+	<variable name="MusicNextPlaying1">
 		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Artist) + String.IsEqual(MusicPlayer.Album,MusicPlayer.Offset(1).Album)">$INFO[MusicPlayer.Offset(1).TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[MusicPlayer.Offset(1).Title]</value>
-		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Artist)">$INFO[MusicPlayer.Offset(1).Album,,[CR]]$INFO[MusicPlayer.Offset(1).TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[MusicPlayer.Offset(1).Title]</value>
-		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Album)">$INFO[MusicPlayer.Offset(1).Artist,,[CR]]$INFO[MusicPlayer.Offset(1).TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[MusicPlayer.Offset(1).Title]</value>
-		<value>$INFO[MusicPlayer.Offset(1).Artist,,[CR]]$INFO[MusicPlayer.Offset(1).Album,,[CR]]$INFO[MusicPlayer.Offset(1).TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[MusicPlayer.Offset(1).Title]</value>
+		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Artist)">$INFO[MusicPlayer.Offset(1).Album,,]</value>
+		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Album)">$INFO[MusicPlayer.Offset(1).Artist,,]</value>
+		<value>$INFO[MusicPlayer.Offset(1).Artist,,]</value>
+	</variable>
+	
+	<variable name="MusicNextPlaying2">
+		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Artist) + String.IsEqual(MusicPlayer.Album,MusicPlayer.Offset(1).Album)"></value>
+		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Artist)">$INFO[MusicPlayer.Offset(1).TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[MusicPlayer.Offset(1).Title]</value>
+		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Album)">$INFO[MusicPlayer.Offset(1).TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[MusicPlayer.Offset(1).Title]</value>
+		<value>$INFO[MusicPlayer.Offset(1).Album,,]</value>
+	</variable>
+	
+	<variable name="MusicNextPlaying3">
+		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Artist) + String.IsEqual(MusicPlayer.Album,MusicPlayer.Offset(1).Album)"></value>
+		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Artist)"></value>
+		<value condition="String.IsEqual(MusicPlayer.Artist,MusicPlayer.Offset(1).Album)"></value>
+		<value>$INFO[MusicPlayer.Offset(1).TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[MusicPlayer.Offset(1).Title]</value>
 	</variable>
 
 	<!-- Media images -->

--- a/16x9/Viewtype51.xml
+++ b/16x9/Viewtype51.xml
@@ -79,7 +79,7 @@
 					<left>0</left>
 					<top>474</top>
 					<width>450</width>
-					<height>246</height>
+					<height>190</height>
 					<label>$VAR[Plot]</label>
 					<textcolor>TextColor1</textcolor>
 					<autoscroll delay="5000" time="1400" repeat="10000">true</autoscroll>


### PR DESCRIPTION
DialogMusicInfo.xml:
- add track duration to music info dialog

DialogMusicInfo.xml, DialogPVRInfo.xml, DialogVideoInfo.xml:
- replace duration label by a global variable for duration labels (for music, PVR and video)

DialogVideoInfo.xml:
- add "p" to resolution in video info dialog and alter representation of 4K resolutions to "2160p" (global variable used here)

Includes.xml:
- move window headings and system time slightly downwards to avoid collision/overlap with "now playing" dialog (if music/video/PVR titles are very long)
- add seconds to system time (more acurate and easier to see, if the system crashed e.g.)
- adjust width of now playing dialog (to avoid collision with main menu items)
- adjust now playing dalog for tv shows (old format: s1e1, new format: S01E01 - capital letters and leading zeros added)
- add ": " to music now playing dailog when showing artist and album (a seperator is useful here!)
- adjust time and time remaining line in now playing dialogs (copy the syntax of e.g. VideoFullScreen.xml "Current Time/End Time")
- move MediaFlags up a bit tp allow two-line representation (first line for video, second for audio information)
- add a label for 3D files under MediaFlags (global variable used here)
- add a label for Atmos/DTS:X audio streams (global variable used here)
- adjust representation of audio codec IDs and channel layout (global variables used here)
- move duration label a bit to the left to clarify difference to MediFlag labels (whitespace added in between those two as well)

MusicVisualisation.xml:
- complete redo of "Now playing" label (all lines turned into fadelabels to scroll long titles, add audio information - codec, bitrate, channel layout and sample rate -, clobal variables used here)
- complete redo of "Next playing" label (all lines turned into fadelabels to scroll long titles, global variables used here as lables with [CR] can't be scrolled)

Variables.xml:
- complete redo variable "AudioChannels" (not only stereo and surround as output, but all supported channel layouts)
- add variable "MusicPlayerChannels" (to be used in MusicVisualisation.xml)
- add variables under "Audio Codec labels" (Atmos, DTSX, AudioCodec and MusicPlayerCodec - to be used in Includes.xml and MusicVisualisation.xml)
- add variable "Duration" (global, easy to use variable for any duration representation of files - differentiating between 00 output and 00:00:00 output)
- add variable "VideoResolution" (output resolution values except 4K which should be converted to 2160)
- add variable "VideoCodec" (translation of Kodi's codec IDs into known codec names)
- add variable "3DMode" (either use "ListItem.IsStereoscopic" - which just works after a first playback mostly - or file/path name syntax - based on Kodi wiki suggestions - to show a 3D label)
- add variables "Seasonplaying" and "Episodeplaying" (adjust old season/episode representation format: s1e1 -> new format: S01E01 - capital letters and leading zeros added)
- add variables "MusicNextPlaying1", "MusicNextPlaying2" and "MusicNextPlaying3" (one for each line required in the next playing dialog in MusicVisualisation.xml, not all lines are always required -> variables needed)

Viewtype51.xml:
- adjust text box hight of plots show when selecting a TV show episode (to avoid collision with new MediaFlags representation)