### PR TITLE
Remove double information on episodes screen

### DIFF
--- a/16x9/Variables.xml
+++ b/16x9/Variables.xml
@@ -386,19 +386,8 @@
 	</variable>
 
 	<variable name="Label2-episodes">
-		<value condition="!String.IsEmpty(ListItem.Season) + !String.IsEmpty(ListItem.Episode) + !String.IsEmpty(ListItem.Date)">$INFO[ListItem.Season,$LOCALIZE[20373] ] &#8226; $INFO[ListItem.Episode,$LOCALIZE[20359] ] &#8226; $INFO[ListItem.Date,$LOCALIZE[20416]: ,]</value>
-		<value condition="!String.IsEmpty(ListItem.Season) + !String.IsEmpty(ListItem.Episode) + !String.IsEmpty(ListItem.Premiered)">$INFO[ListItem.Season,$LOCALIZE[20373] ] &#8226; $INFO[ListItem.Episode,$LOCALIZE[20359] ] &#8226; $INFO[ListItem.Premiered,$LOCALIZE[20416]: ,]</value>
-		<value condition="!String.IsEmpty(ListItem.Season) + !String.IsEmpty(ListItem.Episode)">$INFO[ListItem.Season,$LOCALIZE[20373] ] &#8226; $INFO[ListItem.Episode,$LOCALIZE[20359] ]</value>
-
-		<value condition="!String.IsEmpty(ListItem.Season) + !String.IsEmpty(ListItem.Episode) + !String.IsEmpty(ListItem.Date)">$INFO[ListItem.Season,$LOCALIZE[20373] ] &#8226; $INFO[ListItem.Date,$LOCALIZE[20416]: ,]</value>
-		<value condition="Container.Content(episodes) + !String.IsEmpty(ListItem.Season) + !String.IsEmpty(ListItem.Episode) + !String.IsEmpty(ListItem.Premiered)">$INFO[ListItem.Season,$LOCALIZE[20373] ] &#8226; $INFO[ListItem.Premiered,$LOCALIZE[20416]: ,]</value>
-		<value condition="String.IsEmpty(ListItem.Season) + String.IsEmpty(ListItem.Episode)">$INFO[ListItem.Season,$LOCALIZE[20373] ]</value>
-
-		<value condition="String.IsEmpty(ListItem.Season) + !String.IsEmpty(ListItem.Episode) + !String.IsEmpty(ListItem.Date)">$INFO[ListItem.Episode,$LOCALIZE[20359] ] &#8226; $INFO[ListItem.Date,$LOCALIZE[20416]: ,]</value>
-		<value condition="String.IsEmpty(ListItem.Season) + !String.IsEmpty(ListItem.Episode) + !String.IsEmpty(ListItem.Premiered)">$INFO[ListItem.Episode,$LOCALIZE[20359] ] &#8226; $INFO[ListItem.Premiered,$LOCALIZE[20416]: ,]</value>
-
-		<value condition="String.IsEmpty(ListItem.Season) + String.IsEmpty(ListItem.Episode) + !String.IsEmpty(ListItem.Date)">Aired on $INFO[ListItem.Date]</value>
-		<value condition="String.IsEmpty(ListItem.Season) + String.IsEmpty(ListItem.Episode) + !String.IsEmpty(ListItem.Premiered)">Aired on $INFO[ListItem.Premiered]</value>
+		<value condition="!String.IsEmpty(ListItem.Date)">$INFO[ListItem.Date,$LOCALIZE[20416]: ,]</value>
+		<value condition="!String.IsEmpty(ListItem.Premiered)">$INFO[ListItem.Premiered,$LOCALIZE[20416]: ,]</value>
 	</variable>
 
 		<!-- Audio Channel labels -->


### PR DESCRIPTION
Variables.xml:
- reduce second line information of selected episodes (only first air date shown, season and episode number are already shown in the main title and in the information box on the left)