### PR TITLE
Bug fixes #1

### DIFF
--- a/16x9/Includes.xml
+++ b/16x9/Includes.xml
@@ -514,7 +514,16 @@
 				<width>auto</width>
 				<height>44</height>
 				<align>right</align>
-				<label>$INFO[ListItem.Size,  /  $LOCALIZE[289]: ,]</label>
+				<label>  /  </label>
+				<font>Font33</font>
+				<textcolor>TextColor2</textcolor>
+				<visible>!String.IsEmpty(ListItem.Duration) + !Container.Content(tvshows) + !Container.Content(seasons) + !ListItem.IsFolder + !String.IsEqual(ListItem.Size,0 B)</visible>
+			</control>
+			<control type="label">
+				<width>auto</width>
+				<height>44</height>
+				<align>right</align>
+				<label>$INFO[ListItem.Size,$LOCALIZE[289]: ,]</label>
 				<font>Font33</font>
 				<textcolor>TextColor2</textcolor>
 				<visible>!ListItem.IsFolder + !String.IsEqual(ListItem.Size,0 B)</visible>

--- a/16x9/MusicVisualisation.xml
+++ b/16x9/MusicVisualisation.xml
@@ -32,77 +32,67 @@
 			</control>
 
 			<!-- Now playing -->
-			<control type="fadelabel">
+			<control type="grouplist">
+				<include>VisibleFadeAnimation</include>
+				<include>WindowFadeAnimation</include>
 				<left>980</left>
 				<top>340</top>
-				<width>700</width>
-				<height>40</height>
-				<pauseatend>5000</pauseatend>
-				<label>$INFO[MusicPlayer.Artist,,]</label>
-			</control>
-			<control type="fadelabel">
-				<left>980</left>
-				<top>380</top>
-				<width>700</width>
-				<height>40</height>
-				<pauseatend>5000</pauseatend>
-				<label>$INFO[MusicPlayer.Album,,]</label>
-			</control>
-			<control type="fadelabel">
-				<left>980</left>
-				<top>420</top>
-				<width>700</width>
-				<height>40</height>
-				<pauseatend>5000</pauseatend>
-				<label>$INFO[MusicPlayer.TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[Player.Title,,]</label>
-			</control>
-			<control type="label">
-				<left>980</left>
-				<top>460</top>
-				<width>700</width>
-				<height>40</height>
-				<label>$INFO[VideoPlayer.ChannelName,[LIGHT],[/LIGHT][CR]]$VAR[MusicPlayerCodec,[LIGHT],[/LIGHT]  ]$INFO[MusicPlayer.BitRate,[LIGHT](,kBit/s)[/LIGHT]  ]$VAR[MusicPlayerChannels,[LIGHT],[/LIGHT]  ]$INFO[MusicPlayer.SampleRate,[LIGHT],kHz[/LIGHT]]</label>
+				<hight>200</hight>
+				<control type="fadelabel">
+					<width>700</width>
+					<pauseatend>5000</pauseatend>
+					<label>$INFO[MusicPlayer.Artist]</label>
+					<visible>!String.IsEmpty(MusicPlayer.Artist)</visible>
+				</control>
+				<control type="fadelabel">
+					<width>700</width>
+					<pauseatend>5000</pauseatend>
+					<label>$INFO[MusicPlayer.Album]</label>
+					<visible>!String.IsEmpty(MusicPlayer.Album)</visible>
+				</control>
+				<control type="fadelabel">
+					<width>700</width>
+					<pauseatend>5000</pauseatend>
+					<label>$INFO[MusicPlayer.TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[Player.Title]</label>
+				</control>
+				<control type="fadelabel">
+					<width>700</width>
+					<label>$INFO[VideoPlayer.ChannelName,[LIGHT],[/LIGHT]]</label>
+					<visible>!String.IsEmpty(VideoPlayer.ChannelName)</visible>
+				</control>
+				<control type="label">
+					<width>700</width>
+					<label>$VAR[MusicPlayerCodec,[LIGHT],[/LIGHT]  ]$INFO[MusicPlayer.BitRate,[LIGHT](,kBit/s)[/LIGHT]  ]$VAR[MusicPlayerChannels,[LIGHT],[/LIGHT]  ]$INFO[MusicPlayer.SampleRate,[LIGHT],kHz[/LIGHT]]</label>
+				</control>
 			</control>
 
 			<!-- Next playing -->
-			<control type="label">
+			<control type="grouplist">
+				<visible>!String.IsEmpty(MusicPlayer.Offset(1).Title)</visible>
+				<include>VisibleFadeAnimation</include>
+				<include>WindowFadeAnimation</include>
 				<left>980</left>
 				<top>600</top>
-				<width>700</width>
-				<height>40</height>
-				<font>font27</font>
-				<label>[LIGHT]$LOCALIZE[209]:[/LIGHT]</label>
-				<visible>!String.IsEmpty(MusicPlayer.Offset(1).Title)</visible>
-			</control>
-			<control type="fadelabel">
-				<left>980</left>
-				<top>645</top>
-				<width>700</width>
-				<height>30</height>
-				<font>font27</font>
-				<pauseatend>5000</pauseatend>
-				<label>$VAR[MusicNextPlaying1,,]</label>
-				<visible>!String.IsEmpty(MusicPlayer.Offset(1).Title)</visible>
-			</control>
-			<control type="fadelabel">
-				<left>980</left>
-				<top>675</top>
-				<width>700</width>
-				<height>30</height>
-				<font>font27</font>
-				<pauseatend>5000</pauseatend>
-				<label>$VAR[MusicNextPlaying2,,]</label>
-				<visible>!String.IsEmpty(MusicPlayer.Offset(1).Title)</visible>
-			</control>
-			<control type="fadelabel">
-				<left>980</left>
-				<top>705</top>
-				<width>700</width>
-				<height>30</height>
-				<font>font27</font>
-				<pauseatend>5000</pauseatend>
-				<label>$VAR[MusicNextPlaying3,,]</label>
-				<visible>!String.IsEmpty(MusicPlayer.Offset(1).Title)</visible>
+				<hight>220</hight>
+				<control type="label">
+					<font>font27</font>
+					<label>[LIGHT]$LOCALIZE[209]:[/LIGHT]</label>
+				</control>
+				<control type="fadelabel">
+					<font>font27</font>
+					<pauseatend>5000</pauseatend>
+					<label>$VAR[MusicNextPlaying1,,]</label>
+				</control>
+				<control type="fadelabel">
+					<font>font27</font>
+					<pauseatend>5000</pauseatend>
+					<label>$VAR[MusicNextPlaying2,,]</label>
+				</control>
+				<control type="fadelabel">
+					<font>font27</font>
+					<pauseatend>5000</pauseatend>
+					<label>$VAR[MusicNextPlaying3,,]</label>
+				</control>
 			</control>
 		</control>
 
@@ -228,6 +218,17 @@
 					<font>Font27</font>
 					<textcolor>DialogColor2</textcolor>
 					<label>$INFO[Player.Time] / $INFO[Player.Duration]</label>
+					<visible>Player.HasDuration</visible>
+				</control>
+				
+				<control type="label">
+					<left>20</left>
+					<width>260</width>
+					<height>60</height>
+					<font>Font27</font>
+					<textcolor>DialogColor2</textcolor>
+					<label>$INFO[Player.Time]</label>
+					<visible>!Player.HasDuration</visible>
 				</control>
 
 				<!--  Progress bar -->
@@ -267,6 +268,18 @@
 					<font>Font27</font>
 					<textcolor>DialogColor2</textcolor>
 					<label>$INFO[System.Time,$LOCALIZE[142] , / ]$INFO[Player.FinishTime,$LOCALIZE[19081] ]</label>
+					<visible>Player.HasDuration</visible>
+				</control>
+				
+				<control type="label">
+					<left>1001</left>
+					<width>600</width>
+					<height>60</height>
+					<align>right</align>
+					<font>Font27</font>
+					<textcolor>DialogColor2</textcolor>
+					<label>$INFO[System.Time,$LOCALIZE[142] ,]</label>
+					<visible>!Player.HasDuration</visible>
 				</control>
 
 			</control>

--- a/16x9/Variables.xml
+++ b/16x9/Variables.xml
@@ -331,7 +331,7 @@
 	</variable>
 
 	<variable name="SongLabel">
-		<value condition="Container.Content(songs) + !String.IsEmpty(ListItem.TrackNumber)">$INFO[ListItem.TrackNumber,,. ]$INFO[ListItem.Title]</value>
+		<!-- <value condition="Container.Content(songs) + !String.IsEmpty(ListItem.TrackNumber)">$INFO[ListItem.TrackNumber,,. ]$INFO[ListItem.Title]</value> -->
 		<value>$INFO[ListItem.Label]</value>
 	</variable>
 

--- a/16x9/VideoOSD.xml
+++ b/16x9/VideoOSD.xml
@@ -136,6 +136,17 @@
 				<font>Font27</font>
 				<textcolor>DialogColor2</textcolor>
 				<label>$INFO[Player.Time] / $INFO[Player.Duration]</label>
+				<visible>Player.HasDuration</visible>
+			</control>
+			
+			<control type="label">
+				<left>20</left>
+				<width>260</width>
+				<height>60</height>
+				<font>Font27</font>
+				<textcolor>DialogColor2</textcolor>
+				<label>$INFO[Player.Time]]</label>
+				<visible>!Player.HasDuration</visible>
 			</control>
 
 			<!-- Seek slider -->
@@ -187,6 +198,18 @@
 				<font>Font27</font>
 				<textcolor>DialogColor2</textcolor>
 				<label>$INFO[System.Time,$LOCALIZE[142] , / ]$INFO[Player.FinishTime,$LOCALIZE[19081] ]</label>
+				<visible>Player.HasDuration</visible>
+			</control>
+			
+			<control type="label">
+				<left>1001</left>
+				<width>600</width>
+				<height>60</height>
+				<align>right</align>
+				<font>Font27</font>
+				<textcolor>DialogColor2</textcolor>
+				<label>$INFO[System.Time,$LOCALIZE[142] ,]</label>
+				<visible>!Player.HasDuration</visible>
 			</control>
 
 		</control>


### PR DESCRIPTION
Includes.xml:
- hide sperator between duration and file size, if the selected file has no duration

MusicVisualisation.xml:
- adjust "Now playing" and "Next playing" in the MusicVisualisation window to hide lines, if required information is not present in the music file tags
- hide duration label in the playback OSD for audio streams (if there's no duration)

Variables.xml:
- remove a line of the "SongLabel" variable to let the "sort by" option in music navigation take proper effect

VideoOSD.xml:
- hide duration label in the playback OSD for video streams (if there's no duration)