### PR TITLE
Bug fix #3

### DIFF
--- a/16x9/VideoFullScreen.xml
+++ b/16x9/VideoFullScreen.xml
@@ -146,6 +146,17 @@
 					<font>Font27</font>
 					<textcolor>DialogColor2</textcolor>
 					<label>$INFO[Player.Time] / $INFO[Player.Duration]</label>
+					<visible>Player.HasDuration</visible>
+				</control>
+				
+				<control type="label" id="1">
+					<left>20</left>
+					<width>260</width>
+					<height>60</height>
+					<font>Font27</font>
+					<textcolor>DialogColor2</textcolor>
+					<label>$INFO[Player.Time]</label>
+					<visible>!Player.HasDuration</visible>
 				</control>
 
 				<!--  Progress bar -->
@@ -185,6 +196,18 @@
 					<font>Font27</font>
 					<textcolor>DialogColor2</textcolor>
 					<label>$INFO[System.Time,$LOCALIZE[142] , / ]$INFO[Player.FinishTime,$LOCALIZE[19081] ]</label>
+					<visible>Player.HasDuration</visible>
+				</control>
+				
+				<control type="label" id="1">
+					<left>1001</left>
+					<width>600</width>
+					<height>60</height>
+					<align>right</align>
+					<font>Font27</font>
+					<textcolor>DialogColor2</textcolor>
+					<label>$INFO[System.Time,$LOCALIZE[142] ,]</label>
+					<visible>!Player.HasDuration</visible>
 				</control>
 
 			</control>


### PR DESCRIPTION
VideoFullScreen.xml:
- hide duration label in the playback OSD for video streams (if there's no duration)